### PR TITLE
refactor: Clean up MVVM pattern violations and improve code organization

### DIFF
--- a/JsonSurfer.App/Behaviors/DropFileBehavior.cs
+++ b/JsonSurfer.App/Behaviors/DropFileBehavior.cs
@@ -1,0 +1,84 @@
+using Microsoft.Xaml.Behaviors;
+using System.Linq;
+using System.Windows;
+using System.Windows.Input;
+using JsonSurfer.App.ViewModels;
+
+namespace JsonSurfer.App.Behaviors;
+
+public class DropFileBehavior : Behavior<FrameworkElement>
+{
+    public static readonly DependencyProperty DropCommandProperty =
+        DependencyProperty.Register(
+            nameof(DropCommand),
+            typeof(ICommand),
+            typeof(DropFileBehavior),
+            new PropertyMetadata(null));
+
+    public ICommand? DropCommand
+    {
+        get => (ICommand?)GetValue(DropCommandProperty);
+        set => SetValue(DropCommandProperty, value);
+    }
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.AllowDrop = true;
+            AssociatedObject.DragEnter += OnDragEnter;
+            AssociatedObject.DragOver += OnDragOver;
+            AssociatedObject.Drop += OnDrop;
+        }
+    }
+
+    protected override void OnDetaching()
+    {
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.DragEnter -= OnDragEnter;
+            AssociatedObject.DragOver -= OnDragOver;
+            AssociatedObject.Drop -= OnDrop;
+        }
+        base.OnDetaching();
+    }
+
+    private void OnDragEnter(object sender, DragEventArgs e)
+    {
+        HandleDragEvent(e);
+    }
+
+    private void OnDragOver(object sender, DragEventArgs e)
+    {
+        HandleDragEvent(e);
+    }
+
+    private void OnDrop(object sender, DragEventArgs e)
+    {
+        if (e.Data.GetDataPresent(DataFormats.FileDrop))
+        {
+            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+            DropCommand?.Execute(files);
+        }
+        e.Handled = true;
+    }
+
+    private void HandleDragEvent(DragEventArgs e)
+    {
+        if (e.Data.GetDataPresent(DataFormats.FileDrop))
+        {
+            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+            
+            // Use static method to check if files are valid
+            bool canAccept = files.Any(MainViewModel.IsValidJsonFile);
+            
+            e.Effects = canAccept ? DragDropEffects.Copy : DragDropEffects.None;
+        }
+        else
+        {
+            e.Effects = DragDropEffects.None;
+        }
+        e.Handled = true;
+    }
+}

--- a/JsonSurfer.App/Behaviors/MouseWheelZoomBehavior.cs
+++ b/JsonSurfer.App/Behaviors/MouseWheelZoomBehavior.cs
@@ -1,0 +1,69 @@
+using Microsoft.Xaml.Behaviors;
+using System.Windows;
+using System.Windows.Input;
+
+namespace JsonSurfer.App.Behaviors;
+
+public class MouseWheelZoomBehavior : Behavior<FrameworkElement>
+{
+    public static readonly DependencyProperty ZoomInCommandProperty =
+        DependencyProperty.Register(
+            nameof(ZoomInCommand),
+            typeof(ICommand),
+            typeof(MouseWheelZoomBehavior),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty ZoomOutCommandProperty =
+        DependencyProperty.Register(
+            nameof(ZoomOutCommand),
+            typeof(ICommand),
+            typeof(MouseWheelZoomBehavior),
+            new PropertyMetadata(null));
+
+    public ICommand? ZoomInCommand
+    {
+        get => (ICommand?)GetValue(ZoomInCommandProperty);
+        set => SetValue(ZoomInCommandProperty, value);
+    }
+
+    public ICommand? ZoomOutCommand
+    {
+        get => (ICommand?)GetValue(ZoomOutCommandProperty);
+        set => SetValue(ZoomOutCommandProperty, value);
+    }
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.PreviewMouseWheel += OnPreviewMouseWheel;
+        }
+    }
+
+    protected override void OnDetaching()
+    {
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.PreviewMouseWheel -= OnPreviewMouseWheel;
+        }
+        base.OnDetaching();
+    }
+
+    private void OnPreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        if (Keyboard.Modifiers == ModifierKeys.Control)
+        {
+            e.Handled = true;
+            
+            if (e.Delta > 0)
+            {
+                ZoomInCommand?.Execute(null);
+            }
+            else
+            {
+                ZoomOutCommand?.Execute(null);
+            }
+        }
+    }
+}

--- a/JsonSurfer.App/Behaviors/PropertyGridBehavior.cs
+++ b/JsonSurfer.App/Behaviors/PropertyGridBehavior.cs
@@ -1,0 +1,47 @@
+using Microsoft.Xaml.Behaviors;
+using System.Windows;
+using System.Windows.Input;
+using Xceed.Wpf.Toolkit;
+using Xceed.Wpf.Toolkit.PropertyGrid;
+
+namespace JsonSurfer.App.Behaviors;
+
+public class PropertyGridBehavior : Behavior<PropertyGrid>
+{
+    public static readonly DependencyProperty PropertyValueChangedCommandProperty =
+        DependencyProperty.Register(
+            nameof(PropertyValueChangedCommand),
+            typeof(ICommand),
+            typeof(PropertyGridBehavior),
+            new PropertyMetadata(null));
+
+    public ICommand? PropertyValueChangedCommand
+    {
+        get => (ICommand?)GetValue(PropertyValueChangedCommandProperty);
+        set => SetValue(PropertyValueChangedCommandProperty, value);
+    }
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.PropertyValueChanged += OnPropertyValueChanged;
+        }
+    }
+
+    protected override void OnDetaching()
+    {
+        if (AssociatedObject != null)
+        {
+            AssociatedObject.PropertyValueChanged -= OnPropertyValueChanged;
+        }
+        base.OnDetaching();
+    }
+
+    private void OnPropertyValueChanged(object sender, PropertyValueChangedEventArgs e)
+    {
+        PropertyValueChangedCommand?.Execute(e);
+        System.Diagnostics.Debug.WriteLine($"PropertyGrid value changed: {e.OldValue} -> {e.NewValue}");
+    }
+}

--- a/JsonSurfer.App/JsonSurfer.App.csproj
+++ b/JsonSurfer.App/JsonSurfer.App.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Extended.Wpf.Toolkit" Version="4.7.25104.5739" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JsonSurfer.App/MainWindow.xaml
+++ b/JsonSurfer.App/MainWindow.xaml
@@ -2,15 +2,16 @@
     x:Class="JsonSurfer.App.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:behaviors="clr-namespace:JsonSurfer.App.Behaviors"
     xmlns:controls="clr-namespace:JsonSurfer.App.Views.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:local="clr-namespace:JsonSurfer.App"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
     Title="{Binding WindowTitle}"
     Width="1600"
     Height="800"
-    AllowDrop="True"
     mc:Ignorable="d">
 
     <!--  Keyboard Shortcuts  -->
@@ -53,6 +54,15 @@
             Command="{Binding ResetZoomCommand}"
             Modifiers="Ctrl" />
     </Window.InputBindings>
+
+    <!--  Behaviors for MVVM compliance  -->
+    <i:Interaction.Behaviors>
+        <behaviors:DropFileBehavior 
+            DropCommand="{Binding HandleFileDropCommand}" />
+        <behaviors:MouseWheelZoomBehavior 
+            ZoomInCommand="{Binding ZoomInCommand}"
+            ZoomOutCommand="{Binding ZoomOutCommand}" />
+    </i:Interaction.Behaviors>
 
     <Grid>
         <Grid.RowDefinitions>
@@ -129,8 +139,11 @@
                     <controls:JsonTreeView Grid.Column="0" DataContext="{Binding}" />
                     <GridSplitter Grid.Column="1" HorizontalAlignment="Stretch" />
                     <Grid Grid.Column="2">
-                        <xctk:PropertyGrid SelectedObject="{Binding SelectedNode}" 
-                                          PropertyValueChanged="PropertyGrid_PropertyValueChanged" />
+                        <xctk:PropertyGrid SelectedObject="{Binding SelectedNode}">
+                            <i:Interaction.Behaviors>
+                                <behaviors:PropertyGridBehavior PropertyValueChangedCommand="{Binding HandlePropertyValueChangedCommand}" />
+                            </i:Interaction.Behaviors>
+                        </xctk:PropertyGrid>
                     </Grid>
                 </Grid>
             </TabItem>

--- a/JsonSurfer.App/MainWindow.xaml.cs
+++ b/JsonSurfer.App/MainWindow.xaml.cs
@@ -112,7 +112,7 @@ public partial class MainWindow : Window
         if (e.Data.GetDataPresent(DataFormats.FileDrop))
         {
             string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-            e.Effects = files.Any(IsValidJsonFile) ? DragDropEffects.Copy : DragDropEffects.None;
+            e.Effects = files.Any(MainViewModel.IsValidJsonFile) ? DragDropEffects.Copy : DragDropEffects.None;
         }
         else
         {
@@ -126,7 +126,7 @@ public partial class MainWindow : Window
         if (e.Data.GetDataPresent(DataFormats.FileDrop))
         {
             string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-            return files.FirstOrDefault(IsValidJsonFile);
+            return files.FirstOrDefault(MainViewModel.IsValidJsonFile);
         }
         return null;
     }
@@ -265,26 +265,15 @@ public partial class MainWindow : Window
 
     private void MainWindow_DragEnter(object sender, DragEventArgs e)
     {
-        // Check if the data object contains file list
         if (e.Data.GetDataPresent(DataFormats.FileDrop))
         {
             string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-            
-            // Check if any of the files has valid JSON extension
-            if (files.Any(file => IsValidJsonFile(file)))
-            {
-                e.Effects = DragDropEffects.Copy;
-            }
-            else
-            {
-                e.Effects = DragDropEffects.None;
-            }
+            e.Effects = _viewModel.CanAcceptFiles(files) ? DragDropEffects.Copy : DragDropEffects.None;
         }
         else
         {
             e.Effects = DragDropEffects.None;
         }
-        
         e.Handled = true;
     }
 
@@ -299,58 +288,17 @@ public partial class MainWindow : Window
         if (e.Data.GetDataPresent(DataFormats.FileDrop))
         {
             string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-            
-            // Get the first valid JSON file
-            var jsonFile = files.FirstOrDefault(file => IsValidJsonFile(file));
-            
-            if (jsonFile != null)
-            {
-                try
-                {
-                    // Use the ViewModel's file service to read the file
-                    var content = await File.ReadAllTextAsync(jsonFile);
-                    
-                    // Update ViewModel properties
-                    _viewModel.JsonContent = content;
-                    _viewModel.CurrentFilePath = jsonFile;
-                    _viewModel.WindowTitle = $"JsonSurfer - {Path.GetFileName(jsonFile)}";
-                    _viewModel.IsModified = false;
-                    
-                    // Auto-validate the loaded JSON
-                    _viewModel.ValidateJsonCommand.Execute(null);
-                    
-                    // Switch to Code Editor tab to show the loaded content
-                    _viewModel.SelectedTabIndex = 0;
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show($"Failed to load file: {ex.Message}", "Drag & Drop Error", 
-                        MessageBoxButton.OK, MessageBoxImage.Error);
-                }
-            }
+            await _viewModel.HandleFileDropCommand.ExecuteAsync(files);
         }
-        
         e.Handled = true;
     }
 
-    private static bool IsValidJsonFile(string filePath)
-    {
-        if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
-            return false;
-            
-        var extension = Path.GetExtension(filePath).ToLowerInvariant();
-        return extension == ".json" || extension == ".info";
-    }
     
     private void PropertyGrid_PropertyValueChanged(object sender, Xceed.Wpf.Toolkit.PropertyGrid.PropertyValueChangedEventArgs e)
     {
-        // When PropertyGrid value changes, mark as modified and update JSON content ONLY
-        _viewModel.IsModified = true;
-        
-        // Update JSON content from tree without rebuilding the tree (prevents collapse)
-        _viewModel.UpdateJsonContentFromTree();
-        
+        _viewModel.HandlePropertyValueChangedCommand.Execute(null);
         System.Diagnostics.Debug.WriteLine($"PropertyGrid value changed: {e.OldValue} -> {e.NewValue}");
+    }
 
     private void MainWindow_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
     {

--- a/JsonSurfer.App/MainWindow.xaml.cs
+++ b/JsonSurfer.App/MainWindow.xaml.cs
@@ -26,14 +26,6 @@ public partial class MainWindow : Window
         // Get CompareViewModel from DI
         _compareViewModel = serviceProvider.GetRequiredService<CompareViewModel>();
         
-        // Setup drag and drop event handlers
-        Drop += MainWindow_Drop;
-        
-        // Setup mouse wheel event handler for zoom
-        PreviewMouseWheel += MainWindow_PreviewMouseWheel;
-        DragEnter += MainWindow_DragEnter;
-        DragOver += MainWindow_DragOver;
-        
         // Set Compare tab DataContext
         Loaded += MainWindow_Loaded;
     }
@@ -263,59 +255,4 @@ public partial class MainWindow : Window
         return null;
     }
 
-    private void MainWindow_DragEnter(object sender, DragEventArgs e)
-    {
-        if (e.Data.GetDataPresent(DataFormats.FileDrop))
-        {
-            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-            e.Effects = _viewModel.CanAcceptFiles(files) ? DragDropEffects.Copy : DragDropEffects.None;
-        }
-        else
-        {
-            e.Effects = DragDropEffects.None;
-        }
-        e.Handled = true;
-    }
-
-    private void MainWindow_DragOver(object sender, DragEventArgs e)
-    {
-        // Same logic as DragEnter
-        MainWindow_DragEnter(sender, e);
-    }
-
-    private async void MainWindow_Drop(object sender, DragEventArgs e)
-    {
-        if (e.Data.GetDataPresent(DataFormats.FileDrop))
-        {
-            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-            await _viewModel.HandleFileDropCommand.ExecuteAsync(files);
-        }
-        e.Handled = true;
-    }
-
-    
-    private void PropertyGrid_PropertyValueChanged(object sender, Xceed.Wpf.Toolkit.PropertyGrid.PropertyValueChangedEventArgs e)
-    {
-        _viewModel.HandlePropertyValueChangedCommand.Execute(null);
-        System.Diagnostics.Debug.WriteLine($"PropertyGrid value changed: {e.OldValue} -> {e.NewValue}");
-    }
-
-    private void MainWindow_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
-    {
-        if (Keyboard.Modifiers == ModifierKeys.Control)
-        {
-            e.Handled = true;
-            
-            if (e.Delta > 0)
-            {
-                // Scroll up - zoom in
-                _viewModel.ZoomInCommand.Execute(null);
-            }
-            else
-            {
-                // Scroll down - zoom out
-                _viewModel.ZoomOutCommand.Execute(null);
-            }
-        }
-    }
 }

--- a/JsonSurfer.App/ViewModels/MainViewModel.cs
+++ b/JsonSurfer.App/ViewModels/MainViewModel.cs
@@ -560,6 +560,7 @@ public partial class MainViewModel : ObservableObject
         UpdateJsonContentFromTree();
     }
 
+
     private async Task LoadFileFromPath(string filePath)
     {
         try
@@ -588,11 +589,6 @@ public partial class MainViewModel : ObservableObject
             
         var extension = System.IO.Path.GetExtension(filePath).ToLowerInvariant();
         return extension == ".json" || extension == ".info";
-    }
-
-    public bool CanAcceptFiles(string[] files)
-    {
-        return files?.Any(IsValidJsonFile) == true;
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Fixed all MVVMTK0034 warnings by using generated ObservableProperty accessors
- Moved drag & drop business logic from MainWindow to MainViewModel with proper Commands  
- Converted PropertyGrid event handling to use Command pattern
- Significantly reduced MainWindow code-behind complexity

## Changes Made
- **MVVM Compliance**: Fixed 7 MVVMTK0034 warnings by using `IsUpdatingFromTree` and `NodeExpansionStates` properties instead of backing fields
- **Command Pattern**: Added `HandleFileDropCommand` and `HandlePropertyValueChangedCommand` to MainViewModel
- **Code Organization**: Moved `IsValidJsonFile` helper to MainViewModel as public static method
- **UI Separation**: MainWindow now delegates business logic to ViewModel instead of handling it directly

## Test Plan
- [x] Build succeeds with only nullable warnings (no MVVM violations)
- [ ] Drag & drop functionality works correctly for JSON files
- [ ] PropertyGrid value changes still trigger proper updates
- [ ] All existing features remain functional

🤖 Generated with [Claude Code](https://claude.ai/code)