### PR TITLE
feat: Add GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,41 @@
+name: .NET with Code Coverage
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-test:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build project
+      run: dotnet build --no-restore
+
+    - name: Run tests with code coverage
+      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage"
+
+    - name: Install ReportGenerator
+      run: dotnet tool install --global dotnet-reportgenerator-globaltool
+
+    - name: Generate coverage report
+      run: reportgenerator -reports:"**/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:Html
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coveragereport


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to automate the build and test process for the JsonSurfer project.\n\nThe workflow includes the following steps:\n- Checkout code\n- Setup .NET 8.0\n- Restore dependencies\n- Build the project\n- Run tests using xUnit and collect code coverage with Coverlet\n- Generate an HTML coverage report using ReportGenerator\n- Upload the coverage report as a downloadable artifact\n\nThis will provide a solid foundation for implementing TDD.