### PR TITLE
chore: Update CI workflow for GitHub Pages deployment

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,8 +34,14 @@ jobs:
     - name: Generate coverage report
       run: reportgenerator -reports:"**/coverage.cobertura.xml" -targetdir:"coveragereport" -reporttypes:Html
 
-    - name: Upload coverage report
+    - name: Upload coverage report as artifact
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: coveragereport
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./coveragereport


### PR DESCRIPTION
This PR updates the CI workflow to automatically deploy the code coverage report to a gh-pages branch. This enables hosting the report as a static website via GitHub Pages for easy viewing and historical tracking.