### PR TITLE
fix: Grant write permissions for GitHub Pages deployment

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: write
+
 jobs:
   build-and-test:
     runs-on: windows-latest
@@ -39,3 +42,9 @@ jobs:
       with:
         name: coverage-report
         path: coveragereport
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./coveragereport


### PR DESCRIPTION
This PR grants the necessary 'contents: write' permissions to the GitHub Actions workflow, allowing it to successfully push the generated coverage report to the 'gh-pages' branch for static website hosting.